### PR TITLE
add conf_sftp_allow_pubkey for sftp users in sshd.conf

### DIFF
--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -198,6 +198,7 @@ conf_sftp_home_partition: /home
 conf_sftp_group_name: sftpusers
 conf_sftp_directories: []
 conf_sftp_allow_passwords: False
+conf_sftp_allow_pubkey: False
 conf_sftp_enable_selinux_support: False
 conf_sftp_enable_logging: False
 conf_sftp_nologin_shell: /sbin/nologin

--- a/roles/common/templates/etc/ssh/sshd_config.j2
+++ b/roles/common/templates/etc/ssh/sshd_config.j2
@@ -115,6 +115,7 @@ Match Group {{ conf_sftp_group_name }}
   X11Forwarding no
   ForceCommand internal-sftp {{ conf_sftp_enable_logging | ternary('-l VERBOSE', '') }}
   PasswordAuthentication {{ conf_sftp_allow_passwords | ternary('yes', 'no') }}
+  PubkeyAuthentication {{ conf_sftp_allow_pubkey | ternary('yes', 'no') }}
 {% else %}
 Subsystem sftp /usr/lib/openssh/sftp-server
 {% endif %}


### PR DESCRIPTION
Surprise, surprise...we need to support pubkey authentication for our sftp users.