### PR TITLE
Varnish: Allow to extend the default vcl_hash() method

### DIFF
--- a/roles/web/defaults/main.yml
+++ b/roles/web/defaults/main.yml
@@ -148,6 +148,11 @@ conf_varnish_vcl_backend_response: |
   # make Varnish keep all objects for 6 hours beyond their TTL
   set beresp.grace = 6h;
   # set beresp.grace = 2m;
+conf_varnish_vcl_hash: |
+  # Hash cookies for requests that have them.
+  if (req.http.Cookie) {
+      hash_data(req.http.Cookie);
+  }
 
 #
 # rbenv

--- a/roles/web/templates/etc/varnish/default.vcl-41.j2
+++ b/roles/web/templates/etc/varnish/default.vcl-41.j2
@@ -56,10 +56,9 @@ sub vcl_hash {
       hash_data(server.ip);
   }
 
-  # Hash cookies for requests that have them.
-  if (req.http.Cookie) {
-      hash_data(req.http.Cookie);
-  }
+  {% if conf_varnish_vcl_hash is defined %}
+    {{ conf_varnish_vcl_hash }}
+  {% endif %}
 
   return (lookup);
 }

--- a/roles/web/templates/etc/varnish/default.vcl-51.j2
+++ b/roles/web/templates/etc/varnish/default.vcl-51.j2
@@ -59,10 +59,9 @@ sub vcl_hash {
       hash_data(server.ip);
   }
 
-  # Hash cookies for requests that have them.
-  if (req.http.Cookie) {
-      hash_data(req.http.Cookie);
-  }
+  {% if conf_varnish_vcl_hash is defined %}
+    {{ conf_varnish_vcl_hash }}
+  {% endif %}
 
   return (lookup);
 }


### PR DESCRIPTION
Adds a config and makes the cookie hashing the default value of the config.