### PR TITLE
Add support for htaccess_basic_auth_enable

### DIFF
--- a/roles/web/templates/wp_bedrock/htaccess.j2
+++ b/roles/web/templates/wp_bedrock/htaccess.j2
@@ -5,7 +5,7 @@
 {% if item.value.htaccess is defined %}
 {{ item.value.htaccess }}{% endif %}
 
-{% if item.value.htpasswd_password != false %}
+{% if item.value.htpasswd_password != false and item.value.htaccess_basic_auth_enable is not defined or item.value.htaccess_basic_auth_enable == true %}
 # BEGIN Basic Auth
 AuthType Basic
 AuthName "Protectd"


### PR DESCRIPTION
To allow to customize the basic auth handling, but still generating the `.htpasswd` file, the new `htaccess_basic_auth_enable` setting can be set to `false`.

Related: #8.