### PR TITLE
Add support for htaccess_wordpress_enable

### DIFF
--- a/roles/web/templates/wp_bedrock/htaccess.j2
+++ b/roles/web/templates/wp_bedrock/htaccess.j2
@@ -287,6 +287,7 @@ Require user {{ item.key }}
 # END iThemes Security - Do not modify or remove this line
 {% endif %}
 
+{% if item.value.htaccess_wordpress_enable is not defined or item.value.htaccess_wordpress_enable == true %}
 # BEGIN WordPress
 <IfModule mod_rewrite.c>
   RewriteEngine On
@@ -297,3 +298,4 @@ Require user {{ item.key }}
   RewriteRule . /index.php [L]
 </IfModule>
 # END WordPress
+{% endif %}


### PR DESCRIPTION
This is similar to #13 and allows to disable adding the rewrite rules for WordPress.