### PR TITLE
Varnish Config: Remove extra closing brace causing a compiler failure

### DIFF
--- a/roles/web/templates/etc/varnish/default.vcl-51.j2
+++ b/roles/web/templates/etc/varnish/default.vcl-51.j2
@@ -15,7 +15,7 @@ backend default {
   {{ conf_varnish_backend_default }}
   {% if conf_mysql_flavour_debian_family == "percona-xtradb-cluster" %}
 {{ conf_varnish_backend_probe_mysql_default }}
-  {% else %}}
+  {% else %}
 {{ conf_varnish_backend_probe_default }}
   {% endif %}
 }


### PR DESCRIPTION
```
 # systemctl status varnish.service
● varnish.service - Varnish Cache, a high-performance HTTP accelerator
   Loaded: loaded (/lib/systemd/system/varnish.service; enabled; vendor preset: enabled)
   Active: failed (Result: exit-code) since Wed 2020-04-22 20:11:31 UTC; 8s ago
  Process: 3595 ExecStart=/usr/sbin/varnishd -a :6081 -T localhost:60821 -f /etc/varnish/default.vcl -S /etc/varnish/secret -s malloc,256m -p workspac
 Main PID: 203 (code=exited, status=0/SUCCESS)

Apr 22 20:11:31 compute-01 varnishd[3595]:         'acl', 'sub', 'backend', 'probe', 'import',  or 'vcl'
Apr 22 20:11:31 compute-01 varnishd[3595]: Found: '.' at
Apr 22 20:11:31 compute-01 varnishd[3595]: ('/etc/varnish/default.vcl' Line 19 Pos 1)
Apr 22 20:11:31 compute-01 varnishd[3595]: .probe = {
Apr 22 20:11:31 compute-01 varnishd[3595]: #---------
Apr 22 20:11:31 compute-01 varnishd[3595]: Running VCC-compiler failed, exited with 2
Apr 22 20:11:31 compute-01 varnishd[3595]: VCL compilation failed
Apr 22 20:11:31 compute-01 systemd[1]: varnish.service: Control process exited, code=exited status=255
Apr 22 20:11:31 compute-01 systemd[1]: varnish.service: Failed with result 'exit-code'.
Apr 22 20:11:31 compute-01 systemd[1]: Failed to start Varnish Cache, a high-performance HTTP accelerator.
```