### PR TITLE
The 'sudo' option for the Ansible provisioner is deprecated

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -114,7 +114,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       ansible.playbook = "playbooks/generic.yml"
       ansible.inventory_path = "~/.appflow/tenant/appflow-ttss/development/inventory"
       ansible.vault_password_file = "~/.appflow/vault/ttss/development"
-      ansible.sudo = true
+      ansible.become = true
       ansible.tags = ANSIBLE_TAGS
     end
 
@@ -147,7 +147,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       ansible.playbook = "playbooks/generic.yml"
       ansible.inventory_path = "~/.appflow/tenant/appflow-ttss/development/inventory"
       ansible.vault_password_file = "~/.appflow/vault/ttss/development"
-      ansible.sudo = true
+      ansible.become = true
       ansible.tags = ANSIBLE_TAGS
       ansible.skip_tags = ANSIBLE_TAGS_SKIP
     end


### PR DESCRIPTION
When running vagrant up a deprecation notice is currently shown:

> DEPRECATION: The 'sudo' option for the Ansible provisioner is deprecated.
> Please use the 'become' option instead.
> The 'sudo' option will be removed in a future release of Vagrant.

See https://www.vagrantup.com/docs/provisioning/ansible_common.html#sudo and https://www.vagrantup.com/docs/provisioning/ansible_common.html#become.