### PR TITLE
Set default synced_folder_type to virtualbox

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -14,7 +14,7 @@ ANSIBLE_TAGS_SKIP=ENV['ANSIBLE_TAGS_SKIP']
 # Custom settings which can be overriden via Vagrantfile.local.yml
 atlantis_synced_folder_webdev = "~/Documents/webdev/development"
 atlantis_synced_folder_mount_options = 'dmode=0775,fmode=0664'
-atlantis_synced_folder_type = ""
+atlantis_synced_folder_type = "virtualbox"
 atlantis_synced_folder_smb_username = ""
 atlantis_synced_folder_smb_password = ""
 atlantis_vm_hostname = "atlantis"


### PR DESCRIPTION
Vagrant 2.2.8 has added a check for a valid synced_folder_type. This is now causing an error because there's no type set.

![image](https://user-images.githubusercontent.com/617637/83048748-5e662d00-a04a-11ea-8dea-dbaac6913aeb.png)

This PR sets the value to `virtualbox` which is the default type [for the VirtualBox provider](https://www.vagrantup.com/docs/synced-folders/virtualbox.html).