### PR TITLE
Initial support for Telegraf

### DIFF
--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -86,6 +86,45 @@ conf_undwanted_packages_custom: []
 conf_snmpd_enable: false
 
 #
+# lshell
+#
+conf_lshell_enable: false
+conf_lshell_config: |
+  [global]
+  logpath         : /var/log/lshell/
+  loglevel        : 2
+  #logfilename     : %y%m%d-%u
+  #logfilename     : syslog
+  #syslogname      : myapp
+  #include_dir     : /etc/lshell.d/*.conf
+
+  [default]
+  allowed         : ['ls','echo','cd','ll']
+  forbidden       : [';', '&', '|','`','>','<', '$(', '${']
+  #sudo_commands   : ['ls', 'more']
+  warning_counter : 2
+  aliases         : {'ll':'ls -l', 'vim':'rvim'}
+  #intro           : "== My personal intro ==\nWelcome to lshell\nType '?' or 'help' to get the list of allowed commands"
+  #prompt          : "%u@%h"
+  #prompt_short    : 0
+  #timer           : 5
+  #path            : ['/home/bla/','/etc']
+  #home_path       : '/home/bla/'
+  #env_path        : ':/usr/local/bin:/usr/sbin'
+  #allowed_cmd_path: ['/home/bla/bin','/home/bla/stuff/libexec']
+  #env_vars        : {'foo':1, 'bar':'helloworld'}
+  #scp             : 1
+  #scp_upload       : 0
+  #scp_download     : 0
+  #sftp            : 1
+  #overssh         : ['ls', 'rsync']
+  strict          : 0
+  #scpforce        : '/home/bla/uploads/'
+  #history_size     : 100
+  #history_file     : "/home/%u/.lshell_history"
+  #login_script     : "/path/to/myscript.sh"
+
+#
 # Jailkit
 #
 conf_jailkit_enable: false
@@ -219,6 +258,15 @@ conf_sftp_allow_pubkey: False
 conf_sftp_enable_selinux_support: False
 conf_sftp_enable_logging: False
 conf_sftp_nologin_shell: /sbin/nologin
+
+#
+# Telegraf
+#
+conf_telegraf_enable: false
+# conf_telegraf_conf_global: 
+# conf_telegraf_conf_agent: 
+# conf_telegraf_conf_outputs: 
+# conf_telegraf_conf_inputs: 
 
 #
 # Zabbix

--- a/roles/common/handlers/main.yml
+++ b/roles/common/handlers/main.yml
@@ -72,6 +72,9 @@
 - name: handle_restart_nfs
   service: name=nfs-kernel-server state=restarted
 
+- name: handle_restart_telegraf
+  service: name=telegraf state=restarted
+
 - name: handle_assh_configbuild
   shell: /usr/local/go/bin/assh config build > ~/.ssh/config
 

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -104,6 +104,10 @@
 - import_tasks: lvm.yml
   tags: [ common ]
 
+- import_tasks: lshell.yml
+  when: conf_lshell_enable is defined and conf_lshell_enable == true
+  tags: [ common, lshell ]
+
 - import_tasks: jailkit.yml
   when: conf_jailkit_enable is defined and conf_jailkit_enable == true
   tags: [ common, jailkit, jails ]
@@ -195,6 +199,10 @@
 
 - import_tasks: borg.yml
   when: conf_backup_client == true
+  tags: [ common ]
+
+- import_tasks: telegraf.yml
+  when: conf_telegraf_enable is defined and conf_telegraf_enable == true
   tags: [ common ]
 
 - name: include custom playbook tasks

--- a/roles/common/tasks/telegraf.yml
+++ b/roles/common/tasks/telegraf.yml
@@ -1,0 +1,37 @@
+---
+
+# file: playbooks/roles/common/tasks/telegraf.yml
+
+- name: telegraf apt-key (Ubuntu)
+  apt_key:
+    url: "https://repos.influxdata.com/influxdb.key"
+    id: 2582E0C5
+    state: present
+  when: ansible_distribution == "Ubuntu"
+  tags: [ telegraf ]
+
+# - name: "Debian | Add Telegraf repository (using LSB)"
+#   apt_repository:
+#     repo: "deb https://repos.influxdata.com/{{ ansible_distribution|lower }} {{ ansible_lsb.codename }} stable"
+#     filename: "telegraf"
+#     state: present
+#   become: yes
+#   when:
+#     - telegraf_agent_package_method == "repo"
+#     - ansible_lsb is defined
+#     - ansible_lsb.codename is defined
+
+- name: enable repo repos.influxdata.com (Ubuntu)
+  apt_repository: repo='deb https://repos.influxdata.com/{{ ansible_distribution|lower }} {{ ansible_lsb.codename }} stable' update_cache=yes
+  when: ansible_distribution == "Ubuntu"
+  tags: [ telegraf ]
+
+- name: install telegraf (Debian family)
+  package: name=telegraf state=latest
+  when: ansible_os_family == "Debian"
+  tags: [ telegraf ]
+
+- name: deploy /etc/telegraf/telegraf.conf
+  template: src=etc/telegraf/telegraf.conf.j2 dest=/etc/telegraf/telegraf.conf owner=root group={{ conf_root_group }} mode=0644
+  notify: handle_restart_telegraf
+  tags: [ telegraf, telegraf-conf ]

--- a/roles/common/templates/etc/telegraf/telegraf.conf.j2
+++ b/roles/common/templates/etc/telegraf/telegraf.conf.j2
@@ -1,0 +1,19 @@
+#
+# --- THIS FILE IS AUTOMATICALLY PROVISIONED THROUGH ANSIBLE ---
+#
+
+{% if conf_telegraf_conf_global is defined %}
+{{ conf_telegraf_conf_global }}
+{% endif %}
+
+{% if conf_telegraf_conf_agent is defined %}
+{{ conf_telegraf_conf_agent }}
+{% endif %}
+
+{% if conf_telegraf_conf_outputs is defined %}
+{{ conf_telegraf_conf_outputs }}
+{% endif %}
+
+{% if conf_telegraf_conf_inputs is defined %}
+{{ conf_telegraf_conf_inputs }}
+{% endif %}


### PR DESCRIPTION
Initial support for Telegraf has been added and tested against cloud based influxdb.
New config vars include:

```
#
# telegraf
#
conf_telegraf_enable: true
conf_telegraf_conf_global: |
   ...
conf_telegraf_conf_agent: |
   ...
conf_telegraf_conf_outputs: |
   ...
conf_telegraf_conf_inputs: |
   ...
```